### PR TITLE
fix: caches didn't update at all because of constant keys

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,6 +29,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
 
+    env:
+      horus_compile_version: 0.0.1
+
     steps:
       - uses: actions/checkout@v2
 
@@ -44,17 +47,15 @@ jobs:
       - name: Setup BATS
         uses: mig4/setup-bats@v1
 
-      - uses: actions/cache@v2
-        name: Cache ~/.stack
-        with:
-          path: ~/.stack
-          key: "stack"
+      - uses: freckle/stack-cache-action@main
 
       - uses: actions/cache@v2
-        name: Cache ~/.cache/pip
+        name: Cache python dependencies
         with:
-          path: ~/.cache/pip
-          key: "pip-cache"
+          path: ${{ env.pythonLocation }}
+          key: ${{ env.pythonLocation }}-${{ env.horus_compile_version }}
+          restore-keys:
+            ${{ env.pythonLocation }}-
 
       - name: Build
         run: |
@@ -66,7 +67,7 @@ jobs:
           USER: ${{ secrets.PYPI_USER }}
           PASS: ${{ secrets.PYPI_PASSWORD }}
         run: >
-          pip install horus-compile==0.0.1
+          pip install horus-compile=="$horus_compile_version"
           --extra-index-url http://${USER}:${PASS}@139.162.29.35/
           --trusted-host 139.162.29.35
 


### PR DESCRIPTION
Now, we use a special action for stack build, which I decided to trust
     to handle things the right way.

As for python, we ~always generate a cache-miss (by using the sha hash
     of the commit), and then restore from the general cache and then
     save it again (that's how github's cache mechanism
     works ¯\_(ツ)_/¯).