### PR TITLE
fix: labeling now includes all jump destinations

### DIFF
--- a/tests/resources/golden/if_test.gold
+++ b/tests/resources/golden/if_test.gold
@@ -10,5 +10,13 @@ Results:
 Program: resources/golden/if_test.out
 MathS: unsat
 MathS: unsat
+MathS: unsat
+MathS: unsat
+MathS: unsat
+MathS: unsat
+Z3: unsat
+Z3: unsat
+Z3: unsat
+Z3: unsat
 Z3: unsat
 Z3: unsat


### PR DESCRIPTION
Labeling is a stage at which we mark PCs, where control flows might
     jump to or from. They serve an important purpose, as they break
     up segments.

Before this change we didn't include jump destinations into
     labeling. Due to this, sometimes an arc is drawn in a
     Control-Flow Graph to a jump destination, that isn't a start of a
     segment. And, as such, doesn't have any further arcs, although it
     should.

The solution was to also add jump destinations, as segment starts, to
     the list of labels.