### PR TITLE
fix: no longer discard loop segments

### DIFF
--- a/tests/resources/golden/func_gauss.gold
+++ b/tests/resources/golden/func_gauss.gold
@@ -11,6 +11,8 @@ Program: resources/golden/func_gauss.out
 MathS: unsat
 MathS: unsat
 MathS: unsat
+MathS: unsat
+Z3: unsat
 Z3: unsat
 Z3: unsat
 Z3: unsat

--- a/tests/resources/golden/func_peano_prod.gold
+++ b/tests/resources/golden/func_peano_prod.gold
@@ -11,6 +11,8 @@ Program: resources/golden/func_peano_prod.out
 MathS: unsat
 MathS: unsat
 MathS: unsat
+MathS: unsat
 Z3: unsat
 Z3: unsat
+Z3:       X 
 Z3: unsat

--- a/tests/resources/golden/func_prod_mul.gold
+++ b/tests/resources/golden/func_prod_mul.gold
@@ -12,7 +12,9 @@ MathS: unsat
 MathS: unsat
 MathS: unsat
 MathS: unsat
+MathS: unsat
 Z3: unsat
 Z3: unsat
 Z3: unsat
+Z3:       X 
 Z3: unsat

--- a/tests/resources/golden/sat_cause_42.gold
+++ b/tests/resources/golden/sat_cause_42.gold
@@ -10,7 +10,9 @@ Results:
 Program: resources/golden/sat_cause_42.out
 MathS: unsat
 MathS: unsat
+MathS: unsat
 MathS: sat
+Z3: unsat
 Z3: unsat
 Z3: unsat
 Z3: sat


### PR DESCRIPTION
They were discarded before this change, because a DFS would stop on an
     already visited node, without emitting a module. Now, it does.