### PR TITLE
Updated haskell-z3 dependency

### DIFF
--- a/src/Horus/Preprocessor.hs
+++ b/src/Horus/Preprocessor.hs
@@ -21,7 +21,7 @@ import Lens.Micro.Mtl (view)
 import qualified SimpleSMT as SMT
 import Text.Printf (printf)
 import Z3.Base (Goal, Tactic)
-import qualified Z3.Base (Model, modelTranslate)
+import qualified Z3.Base (Model)
 import Z3.Monad (MonadZ3)
 import qualified Z3.Monad as Z3
 
@@ -90,12 +90,11 @@ mkFullModel :: MonadZ3 z3 => Goal -> Text -> PreprocessorT z3 SolverResult
 mkFullModel goal tModel = do
   realContext <- Z3.getContext
   model' <- Z3.local $ do
-    context <- Z3.getContext
     Z3.solverFromString (unpack tModel)
     _ <- Z3.solverCheck -- tModel consists of (declare-fun ...) expressions
     -- so should be okay to ignore the result.
     model <- Z3.solverGetModel
-    liftIO $ Z3.Base.modelTranslate context model realContext
+    Z3.modelTranslate model realContext
   fullModel <- Z3.convertModel goal model'
   model <- z3ModelToHorusModel fullModel
   pure $ Sat model

--- a/stack.yaml
+++ b/stack.yaml
@@ -42,8 +42,8 @@ packages:
 #
 extra-deps:
   - simple-smt-0.9.7@sha256:a93eba88f8177e13b39bf664b53ad65ca8eea976f00cae443c081b3ea3c26fb3,736
-  - git: https://github.com/ElijahVlasov/haskell-z3.git
-    commit: 9d635925d17419174dee1b8d3e7bf87aa763f402
+  - git: https://github.com/IagoAbal/haskell-z3.git
+    commit: fff21420216dd7f501b99ce5b1cbc42aea1339a9
 
 # Override default flag values for local packages and extra-deps
 # flags: {}

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -14,14 +14,14 @@ packages:
 - completed:
     name: z3
     version: '408.2'
-    git: https://github.com/ElijahVlasov/haskell-z3.git
+    git: https://github.com/IagoAbal/haskell-z3.git
     pantry-tree:
       size: 2204
-      sha256: 839604cc4a50b889232329150b7f981d941751d98c0a4b278a82da62fe8070d5
-    commit: 9d635925d17419174dee1b8d3e7bf87aa763f402
+      sha256: 83782d77391a1a2569571a8ab96cc55c160b766a3203a17b5b8df1e68a2c7f0a
+    commit: fff21420216dd7f501b99ce5b1cbc42aea1339a9
   original:
-    git: https://github.com/ElijahVlasov/haskell-z3.git
-    commit: 9d635925d17419174dee1b8d3e7bf87aa763f402
+    git: https://github.com/IagoAbal/haskell-z3.git
+    commit: fff21420216dd7f501b99ce5b1cbc42aea1339a9
 snapshots:
 - completed:
     size: 618884


### PR DESCRIPTION
1. My PR to haskell-z3 has been merged, so no need to use my repo.
2. Minor refactoring: `Z3.Base.modelTranslate` -> `Z3.modelTranslate`.