### PR TITLE
disable model generation when not requested

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE RecordWildCards #-}
-
 module Main (main) where
 
 import Control.Applicative ((<**>))

--- a/horus-check.cabal
+++ b/horus-check.cabal
@@ -16,6 +16,7 @@ common deps
       ImportQualifiedPost
       MultiParamTypeClasses
       OverloadedStrings
+      RecordWildCards
       ScopedTypeVariables
       StandaloneDeriving
       TupleSections

--- a/src/Horus/Arguments.hs
+++ b/src/Horus/Arguments.hs
@@ -12,7 +12,7 @@ import Data.Text (Text, unpack)
 import Options.Applicative
 
 import Horus.Global (Config (..))
-import Horus.Preprocessor.Solvers (Solver, cvc5, mathsat, setTimeout, z3)
+import Horus.Preprocessor.Solvers (Solver, SolverSettings (..), cvc5, mathsat, z3)
 
 data Arguments = Arguments
   { arg_fileName :: FilePath
@@ -47,20 +47,20 @@ configParser =
           <> short 'v'
           <> help "If the flag is set all the intermediate steps are printed out."
       )
-    <*> switch
-      ( long "print-models"
+    <*> option
+      solverReader
+      ( long "solver"
+          <> short 's'
+          <> metavar "SOLVER"
+          <> value z3
           <> showDefault
-          <> help "Print models for SAT results."
+          <> help "Solver to check the resulting smt queries."
       )
-    <*> ( setTimeout
-            <$> option
-              solverReader
-              ( long "solver"
-                  <> short 's'
-                  <> metavar "SOLVER"
-                  <> value z3
+    <*> ( SolverSettings
+            <$> switch
+              ( long "print-models"
                   <> showDefault
-                  <> help "Solver to check the resulting smt queries."
+                  <> help "Print models for SAT results."
               )
             <*> option
               auto

--- a/src/Horus/CairoSemantics.hs
+++ b/src/Horus/CairoSemantics.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE RecordWildCards #-}
 
 module Horus.CairoSemantics
   ( encodeSemantics

--- a/src/Horus/CairoSemantics/Runner.hs
+++ b/src/Horus/CairoSemantics/Runner.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE RecordWildCards #-}
-
 module Horus.CairoSemantics.Runner
   ( SemanticsEnv (..)
   , runT

--- a/src/Horus/ContractDefinition.hs
+++ b/src/Horus/ContractDefinition.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE RecordWildCards #-}
-
 module Horus.ContractDefinition
   ( ContractDefinition (..)
   , Checks (..)

--- a/src/Horus/Instruction.hs
+++ b/src/Horus/Instruction.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE RecordWildCards #-}
-
 module Horus.Instruction
   ( Instruction (..)
   , LabeledInst

--- a/src/Horus/SMTUtil.hs
+++ b/src/Horus/SMTUtil.hs
@@ -4,15 +4,10 @@ module Horus.SMTUtil
   , fp
   , regToTSExpr
   , memory
-  , withSolver
   )
 where
 
-import Control.Exception.Safe (bracket)
-import Data.Text (Text, unpack)
-
 import Horus.Instruction (PointerRegister (..))
-import SimpleSMT qualified (Solver, newSolver, stop)
 import SimpleSMT.Typed (TSExpr)
 import SimpleSMT.Typed qualified as SMT
 
@@ -29,9 +24,3 @@ regToTSExpr FramePointer = fp
 
 memory :: TSExpr Integer -> TSExpr Integer
 memory = SMT.function "memory"
-
-withSolver :: Text -> [Text] -> (SimpleSMT.Solver -> IO a) -> IO a
-withSolver solverName args =
-  bracket
-    (SimpleSMT.newSolver (unpack solverName) (map unpack args) Nothing)
-    SimpleSMT.stop


### PR DESCRIPTION
Solvers sometimes are much faster, when model generation is not
     enabled.