### PR TITLE
use a version of SimpleSMT with fixed exception handling

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -41,7 +41,8 @@ packages:
 #   commit: e7b331f14bcffb8367cd58fbfc8b40ec7642100a
 #
 extra-deps:
-  - simple-smt-0.9.7@sha256:a93eba88f8177e13b39bf664b53ad65ca8eea976f00cae443c081b3ea3c26fb3,736
+  - git: https://github.com/murcake/simple-smt.git
+    commit: 4286d76888cf0d850d925713cd2a991e89cad5f9
   - git: https://github.com/IagoAbal/haskell-z3.git
     commit: fff21420216dd7f501b99ce5b1cbc42aea1339a9
 

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -5,12 +5,16 @@
 
 packages:
 - completed:
-    hackage: simple-smt-0.9.7@sha256:a93eba88f8177e13b39bf664b53ad65ca8eea976f00cae443c081b3ea3c26fb3,736
+    name: simple-smt
+    version: 0.9.7
+    git: https://github.com/murcake/simple-smt.git
     pantry-tree:
-      size: 253
-      sha256: ddbb8343712ef5d96480180f4df7113db80ecb41336ec3e02876ccdb6ff6b547
+      size: 357
+      sha256: 29342bcf3b56e2710741d2c881f8ebe1ba0134799a05f1ec479c7561cebc936d
+    commit: 4286d76888cf0d850d925713cd2a991e89cad5f9
   original:
-    hackage: simple-smt-0.9.7@sha256:a93eba88f8177e13b39bf664b53ad65ca8eea976f00cae443c081b3ea3c26fb3,736
+    git: https://github.com/murcake/simple-smt.git
+    commit: 4286d76888cf0d850d925713cd2a991e89cad5f9
 - completed:
     name: z3
     version: '408.2'


### PR DESCRIPTION
In this version, solvers are terminated when exceptions are
     thrown. That means that the timeout function works as intended.