### PR TITLE
Only use `-Werror` when running `stack install` in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -103,7 +103,7 @@ jobs:
       - name: Build
         run: |
           jobs=$(getconf _NPROCESSORS_ONLN)
-          stack --jobs "$jobs" install
+          stack --jobs "$jobs" install --ghc-options -Werror
 
       - name: Test
         run: bash ./tests/entrypoint.sh

--- a/horus-check.cabal
+++ b/horus-check.cabal
@@ -33,7 +33,7 @@ common deps
       TypeOperators
       ViewPatterns
     ghc-options:
-      -Weverything -Werror
+      -Weverything
       -Wno-safe -Wno-unsafe -Wno-implicit-prelude
       -Wno-all-missed-specializations
       -Wno-missing-deriving-strategies


### PR DESCRIPTION
This commit removes the annoyance of having to make sure there are no unused imports or definitions while debugging. Builds will still fail if warnings are not fixed.

We do this by removing `-Werror` from `horus-check.cabal` and passing it to `--ghc-options` in the CI workflow file.