### PR TITLE
Add support for arbitrary field primes parsed from JSON.

### DIFF
--- a/app/disasm/Main.hs
+++ b/app/disasm/Main.hs
@@ -12,7 +12,7 @@ import System.Environment (getArgs)
 import Horus.ContractDefinition (cd_program)
 import Horus.Instruction (labelInstructions, readAllInstructions, toSemiAsm)
 import Horus.Label (Label (..))
-import Horus.Program (p_code)
+import Horus.Program (p_code, p_prime)
 
 type EIO = ExceptT Text IO
 
@@ -20,7 +20,8 @@ main' :: EIO ()
 main' = do
   filename <- parseArgs =<< liftIO getArgs
   contract <- eioDecodeFileStrict filename
-  instructions <- readAllInstructions (p_code (cd_program contract))
+  let program = cd_program contract
+  instructions <- readAllInstructions (p_prime program) (p_code program)
   semiAsms <- traverse toSemiAsm instructions
   let labels = map fst (labelInstructions instructions)
   for_ (zip labels semiAsms) $ \(Label pc, semiAsm) -> liftIO $ do

--- a/src/Horus/CairoSemantics/Runner.hs
+++ b/src/Horus/CairoSemantics/Runner.hs
@@ -46,7 +46,7 @@ import Horus.FunctionAnalysis (ScopedFunction (sf_scopedName))
 import Horus.SW.Builtin qualified as Builtin (rcBound)
 import Horus.SW.Storage (Storage)
 import Horus.SW.Storage qualified as Storage (read)
-import Horus.Util (fieldPrime, tShow, unlessM)
+import Horus.Util (tShow, unlessM)
 
 data AssertionBuilder
   = QFAss (Expr TBool)
@@ -232,12 +232,9 @@ debugFriendlyModel ConstraintsState{..} =
     | MemoryVariable{..} <- cs_memoryVariables
     ]
 
-constants :: [(Text, Integer)]
-constants = [(pprExpr prime, fieldPrime), (pprExpr rcBound, Builtin.rcBound)]
-
-makeModel :: ConstraintsState -> Text
-makeModel ConstraintsState{..} =
-  Text.intercalate "\n" (decls <> map Command.assert restrictions)
+makeModel :: ConstraintsState -> Integer -> Text
+makeModel ConstraintsState{..} fPrime =
+  Text.intercalate "\n" (decls <> map (Command.assert fPrime) restrictions)
  where
   functions =
     toList (foldMap gatherNonStdFunctions generalRestrictions <> gatherNonStdFunctions prime)
@@ -262,6 +259,8 @@ makeModel ConstraintsState{..} =
       | otherwise -> Just (0 .<= var .&& var .< prime)
      where
       var = Fun name
+      constants :: [(Text, Integer)]
+      constants = [(pprExpr prime, fPrime), (pprExpr rcBound, Builtin.rcBound)]
     _ -> Nothing
 
   restrictMemTail [] = []

--- a/src/Horus/Command/SMT.hs
+++ b/src/Horus/Command/SMT.hs
@@ -18,5 +18,5 @@ declare (Function name) = pack (printf "(declare-fun %s (%s) %s)" name args res)
   res = SMT.showsSExpr resTy ""
   (resTy :| argTys) = Ty.toSMT @ty
 
-assert :: Expr TBool -> Text
-assert e = pack (printf "(assert %s)" (SMT.showsSExpr (Expr.toSMT e) ""))
+assert :: Integer -> Expr TBool -> Text
+assert fPrime e = pack (printf "(assert %s)" (SMT.showsSExpr (Expr.toSMT fPrime e) ""))

--- a/src/Horus/ContractInfo.hs
+++ b/src/Horus/ContractInfo.hs
@@ -51,9 +51,9 @@ data ContractInfo = ContractInfo
 
 mkContractInfo :: forall m'. MonadError Text m' => ContractDefinition -> m' ContractInfo
 mkContractInfo cd = do
-  insts <- mkInstructions
+  insts <- mkInstructions (p_prime program)
   retsByFun <- mkRetsByFun insts
-  lInstrs <- labelInstructions <$> readAllInstructions (p_code (cd_program cd))
+  lInstrs <- labelInstructions <$> readAllInstructions (p_prime program) (p_code program)
   let generatedNames = mkGeneratedNames storageVarsNames
   let sources = mkSources generatedNames
   let inlinables = fromList $ Map.keys $ inlinableFuns insts program cd
@@ -196,8 +196,8 @@ mkContractInfo cd = do
   getInvariant name = Map.lookup name (cd_invariants cd)
 
   ---- non-plain data producers that depend on the outer monad (likely, for errors)
-  mkInstructions :: m' [LabeledInst]
-  mkInstructions = fmap labelInstructions (readAllInstructions (p_code (cd_program cd)))
+  mkInstructions :: Integer -> m' [LabeledInst]
+  mkInstructions fPrime = fmap labelInstructions (readAllInstructions fPrime (p_code (cd_program cd)))
 
   mkRetsByFun :: [LabeledInst] -> m' (Map ScopedName [Label])
   mkRetsByFun insts = do

--- a/src/Horus/Expr/SMT.hs
+++ b/src/Horus/Expr/SMT.hs
@@ -44,8 +44,8 @@ import Horus.Expr.Util (fieldToInt)
 
 -- converting to unsafe syntax
 
-toSMT :: Expr a -> SMT.SExpr
-toSMT = toSMT' . fieldToInt
+toSMT :: Integer -> Expr a -> SMT.SExpr
+toSMT fPrime = toSMT' . fieldToInt fPrime
 
 toSMT' :: Expr a -> SMT.SExpr
 toSMT' True = SMT.bool Prelude.True

--- a/src/Horus/Global.hs
+++ b/src/Horus/Global.hs
@@ -35,7 +35,7 @@ import Horus.Module (Module (..), ModuleL, gatherModules, nameOfModule)
 import Horus.Preprocessor (PreprocessorL, SolverResult (Unknown), goalListToTextList, optimizeQuery, solve)
 import Horus.Preprocessor.Runner (PreprocessorEnv (..))
 import Horus.Preprocessor.Solvers (Solver, SolverSettings, filterMathsat, includesMathsat, isEmptySolver)
-import Horus.Program (Identifiers)
+import Horus.Program (Identifiers, Program (p_prime))
 import Horus.SW.FuncSpec (FuncSpec, FuncSpec' (fs'_pre))
 import Horus.SW.Identifier (Function (..))
 import Horus.SW.ScopedName (ScopedName ())
@@ -61,6 +61,7 @@ data GlobalF a
   | GetIdentifiers (Identifiers -> a)
   | GetInlinable (Set ScopedFunction -> a)
   | GetLabelledInstrs ([LabeledInst] -> a)
+  | GetProgram (Program -> a)
   | GetSources ([(Function, ScopedName, FuncSpec)] -> a)
   | SetConfig Config a
   | PutStrLn' Text a
@@ -107,6 +108,9 @@ getInlinable = liftF' (GetInlinable id)
 
 getLabelledInstructions :: GlobalL [LabeledInst]
 getLabelledInstructions = liftF' (GetLabelledInstrs id)
+
+getProgram :: GlobalL Program
+getProgram = liftF' (GetProgram id)
 
 getSources :: GlobalL [(Function, ScopedName, FuncSpec)]
 getSources = liftF' (GetSources id)
@@ -169,23 +173,27 @@ solveModule m = do
 
 outputSmtQueries :: Text -> ConstraintsState -> GlobalL ()
 outputSmtQueries moduleName constraints = do
+  fPrime <- p_prime <$> getProgram
+  let query = makeModel constraints fPrime
   Config{..} <- getConfig
-  whenJust cfg_outputQueries writeSmtFile
-  whenJust cfg_outputOptimizedQueries writeSmtFileOptimized
+  whenJust cfg_outputQueries (writeSmtFile query)
+  whenJust cfg_outputOptimizedQueries (writeSmtFileOptimized query)
  where
-  query = makeModel constraints
   memVars = map (\mv -> (mv_varName mv, mv_addrName mv)) (cs_memoryVariables constraints)
 
-  writeSmtFile dir = do
+  writeSmtFile :: Text -> FilePath -> GlobalL ()
+  writeSmtFile query dir = do
     writeFile' (dir </> unpack moduleName <> ".smt2") query
 
-  getQueryList = do
+  getQueryList :: Text -> PreprocessorL [Text]
+  getQueryList query = do
     queryList <- optimizeQuery query
     goalListToTextList queryList
 
-  writeSmtFileOptimized dir = do
+  writeSmtFileOptimized :: Text -> FilePath -> GlobalL ()
+  writeSmtFileOptimized query dir = do
     Config{..} <- getConfig
-    queries <- runPreprocessorL (PreprocessorEnv memVars cfg_solver cfg_solverSettings) getQueryList
+    queries <- runPreprocessorL (PreprocessorEnv memVars cfg_solver cfg_solverSettings) (getQueryList query)
     writeSmtQueries queries dir moduleName
 
 writeSmtQueries :: [Text] -> FilePath -> Text -> GlobalL ()
@@ -218,9 +226,10 @@ checkMathsat m = do
 solveSMT :: ConstraintsState -> GlobalL SolverResult
 solveSMT cs = do
   Config{..} <- getConfig
-  runPreprocessorL (PreprocessorEnv memVars cfg_solver cfg_solverSettings) (solve query)
+  fPrime <- p_prime <$> getProgram
+  let query = makeModel cs fPrime
+  runPreprocessorL (PreprocessorEnv memVars cfg_solver cfg_solverSettings) (solve fPrime query)
  where
-  query = makeModel cs
   memVars = map (\mv -> (mv_varName mv, mv_addrName mv)) (cs_memoryVariables cs)
 
 solveContract :: GlobalL [SolvingInfo]

--- a/src/Horus/Global/Runner.hs
+++ b/src/Horus/Global/Runner.hs
@@ -47,6 +47,7 @@ interpret = iterM exec . runGlobalL
   exec (GetIdentifiers cont) = asks (ci_identifiers . e_contractInfo) >>= cont
   exec (GetInlinable cont) = asks (ci_inlinables . e_contractInfo) >>= cont
   exec (GetLabelledInstrs cont) = asks (ci_labelledInstrs . e_contractInfo) >>= cont
+  exec (GetProgram cont) = asks (ci_program . e_contractInfo) >>= cont
   exec (GetSources cont) = asks (ci_sources . e_contractInfo) >>= cont
   exec (SetConfig conf cont) = do
     configRef <- asks e_config

--- a/src/Horus/Instruction.hs
+++ b/src/Horus/Instruction.hs
@@ -124,14 +124,14 @@ jumpDestination _ = Nothing
 n15, n16 :: Int
 (n15, n16) = (15, 16)
 
-readAllInstructions :: MonadError Text m => [Integer] -> m [Instruction]
-readAllInstructions [] = pure []
-readAllInstructions (i : is) = do
-  (instr, is') <- readInstruction (i :| is)
-  (instr :) <$> readAllInstructions is'
+readAllInstructions :: MonadError Text m => Integer -> [Integer] -> m [Instruction]
+readAllInstructions _ [] = pure []
+readAllInstructions fPrime (i : is) = do
+  (instr, is') <- readInstruction fPrime (i :| is)
+  (instr :) <$> readAllInstructions fPrime is'
 
-readInstruction :: forall m. MonadError Text m => NonEmpty Integer -> m (Instruction, [Integer])
-readInstruction (i :| is) = do
+readInstruction :: forall m. MonadError Text m => Integer -> NonEmpty Integer -> m (Instruction, [Integer])
+readInstruction fPrime (i :| is) = do
   let flags = i `shiftR` (3 * 16)
   let dstEnc = i .&. (2 ^ n16 - 1)
   let op0Enc = (i `shiftR` 16) .&. (2 ^ n16 - 1)
@@ -188,7 +188,7 @@ readInstruction (i :| is) = do
             Ret -> Dst
             _ -> KeepFp
         )
-      <*> return (toSignedFelt imm)
+      <*> return (toSignedFelt fPrime imm)
   pure (instruction, is')
  where
   op1Map :: Bool -> Bool -> Bool -> m Op1Source

--- a/src/Horus/Util.hs
+++ b/src/Horus/Util.hs
@@ -1,6 +1,5 @@
 module Horus.Util
-  ( fieldPrime
-  , toSignedFelt
+  ( toSignedFelt
   , whenJust
   , whenJustM
   , unlessM
@@ -28,15 +27,12 @@ import Data.Text (Text, pack)
 import Data.Text qualified as Text
 import Data.Typeable (Typeable, eqT)
 
-fieldPrime :: Integer
-fieldPrime = 2 ^ (251 :: Int) + 17 * 2 ^ (192 :: Int) + 1
-
-toSignedFelt :: Integer -> Integer
-toSignedFelt x
-  | moddedX > fieldPrime `div` 2 = moddedX - fieldPrime
+toSignedFelt :: Integer -> Integer -> Integer
+toSignedFelt fPrime x
+  | moddedX > fPrime `div` 2 = moddedX - fPrime
   | otherwise = moddedX
  where
-  moddedX = x `mod` fieldPrime
+  moddedX = x `mod` fPrime
 
 whenJust :: Applicative f => Maybe a -> (a -> f ()) -> f ()
 whenJust Nothing _ = pure ()


### PR DESCRIPTION
**This is a merge revert of #90, which was already reviewed and approved.**

There is a key in the `"program"` field of the contract definition JSON called `"prime"`, which is the characteristic of the finite field over which all arithmetic is done in the contract. Horus used to hardcode this to a value defined in `Util.hs` called `fieldPrime`, and even though we parsed the actual value from the JSON, it was not used anywhere.

This commit adds support for using the prime passed from `horus-compile` via the JSON contract.
* Add a `GetProgram` constructor to `GlobalF`.
* Add an integer `fPrime` parameter to many functions.
* Refactor `outputSmtQueries`.
* Lint source files (remove a couple redundant brackets).