### PR TITLE
implement reporting of inlined functions

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -55,9 +55,9 @@ main' Arguments{..} = do
   configRef <- liftIO (newIORef arg_config)
   let env = Global.Env{e_config = configRef, e_contractInfo = contractInfo}
   infos <- liftIO (Global.run env solveContract) >>= liftEither
-  for_ infos $ \si -> liftIO $ do
-    TextIO.putStrLn (ppSolvingInfo si)
-  let unknowns = [res | res@(Unknown{}) <- map si_result infos]
+  for_ infos $ \(si, canInline) -> liftIO $ do
+    TextIO.putStrLn (ppSolvingInfo si canInline)
+  let unknowns = [res | res@(Unknown{}) <- map (si_result . fst) infos]
   unless (null unknowns) $ liftIO (TextIO.putStrLn hint')
  where
   hint' = "\ESC[33m" <> (T.strip . T.unlines . map ("hint: " <>) . T.lines) hint <> "\ESC[0m"
@@ -69,8 +69,14 @@ eioDecodeFileStrict path = do
     Left err -> throwError (T.pack err)
     Right res -> pure res
 
-ppSolvingInfo :: SolvingInfo -> Text
-ppSolvingInfo SolvingInfo{..} = si_moduleName <> "\n" <> tShow si_result <> "\n"
+ppSolvingInfo :: SolvingInfo -> Bool -> Text
+ppSolvingInfo SolvingInfo{..} canInline =
+  si_moduleName <> formatInlined <> "\n" <> tShow si_result <> "\n"
+ where
+  formatInlined =
+    if canInline
+      then " [inlined]"
+      else ""
 
 main :: IO ()
 main = do

--- a/horus-check.cabal
+++ b/horus-check.cabal
@@ -54,6 +54,7 @@ library
       Horus.Arguments
       Horus.ContractDefinition
       Horus.ContractInfo
+      Horus.FunctionAnalysis
       Horus.Global
       Horus.Global.Runner
       Horus.Instruction
@@ -68,7 +69,6 @@ library
       Horus.CairoSemantics.Runner
       Horus.Command.SMT
       Horus.CallStack
-      Horus.FunctionAnalysis
       Horus.Expr
       Horus.Expr.SMT
       Horus.Expr.Std
@@ -126,6 +126,7 @@ executable horus-check
     main-is:                 Main.hs
     build-depends:
       aeson,
+      containers,
       directory,
       filepath,
       horus-check,

--- a/tests/resources/golden/bitwise_simple_fake.gold
+++ b/tests/resources/golden/bitwise_simple_fake.gold
@@ -1,5 +1,6 @@
-apply_bitwise
+apply_bitwise [inlined]
 Verified
 
-main
+main [inlined]
 False
+

--- a/tests/resources/golden/bitwise_simple_not_fake.gold
+++ b/tests/resources/golden/bitwise_simple_not_fake.gold
@@ -1,5 +1,6 @@
-apply_bitwise
+apply_bitwise [inlined]
 Verified
 
-main
+main [inlined]
 Verified
+

--- a/tests/resources/golden/ecdsa_simple_fake.gold
+++ b/tests/resources/golden/ecdsa_simple_fake.gold
@@ -1,5 +1,6 @@
-apply_ecdsa
+apply_ecdsa [inlined]
 Verified
 
-main
+main [inlined]
 False
+

--- a/tests/resources/golden/inline_balance_svar_simple.gold
+++ b/tests/resources/golden/inline_balance_svar_simple.gold
@@ -1,5 +1,6 @@
 main
 False
 
-f
+f [inlined]
 Verified
+

--- a/tests/resources/golden/inline_balance_svar_simple_asm.gold
+++ b/tests/resources/golden/inline_balance_svar_simple_asm.gold
@@ -1,5 +1,6 @@
 main
 False
 
-f
+f [inlined]
 Verified
+

--- a/tests/resources/golden/inline_balance_svar_simple_twice.gold
+++ b/tests/resources/golden/inline_balance_svar_simple_twice.gold
@@ -1,5 +1,6 @@
 main
 Verified
 
-get_balance
+get_balance [inlined]
 Verified
+

--- a/tests/resources/golden/inline_basic.gold
+++ b/tests/resources/golden/inline_basic.gold
@@ -1,5 +1,6 @@
 main
 Verified
 
-succ
+succ [inlined]
 Verified
+

--- a/tests/resources/golden/inline_if.gold
+++ b/tests/resources/golden/inline_if.gold
@@ -1,5 +1,6 @@
 main
 Verified
 
-f
+f [inlined]
 Verified
+

--- a/tests/resources/golden/inline_if_sat.gold
+++ b/tests/resources/golden/inline_if_sat.gold
@@ -16,5 +16,6 @@ Verified
 main:::FF
 False
 
-f
+f [inlined]
 Verified
+

--- a/tests/resources/golden/inline_many.gold
+++ b/tests/resources/golden/inline_many.gold
@@ -1,14 +1,15 @@
 main
 Verified
 
-succ
+succ [inlined]
 Verified
 
-pred
+pred [inlined]
 Verified
 
-id
+id [inlined]
 Verified
 
-addtwo
+addtwo [inlined]
 Verified
+

--- a/tests/resources/golden/inline_many_sat.gold
+++ b/tests/resources/golden/inline_many_sat.gold
@@ -1,14 +1,15 @@
 main
 False
 
-succ
+succ [inlined]
 Verified
 
-pred
+pred [inlined]
 Verified
 
-id
+id [inlined]
 Verified
 
-addtwo
+addtwo [inlined]
 Verified
+

--- a/tests/resources/golden/inline_pre_success.gold
+++ b/tests/resources/golden/inline_pre_success.gold
@@ -4,5 +4,6 @@ Verified
 pred
 Verified
 
-succ
+succ [inlined]
 Verified
+

--- a/tests/resources/golden/inline_range_check.gold
+++ b/tests/resources/golden/inline_range_check.gold
@@ -1,5 +1,6 @@
 main
 False
 
-apply_range_check
+apply_range_check [inlined]
 Verified
+

--- a/tests/resources/golden/inline_small.gold
+++ b/tests/resources/golden/inline_small.gold
@@ -4,8 +4,9 @@ False
 pred
 Verified
 
-succ
+succ [inlined]
 Verified
 
-id
+id [inlined]
 Verified
+

--- a/tests/resources/golden/inline_stack_minimal.gold
+++ b/tests/resources/golden/inline_stack_minimal.gold
@@ -1,14 +1,15 @@
 main_
 Verified
 
-_Stack.empty
+_Stack.empty [inlined]
 Verified
 
-_Stack.add
+_Stack.add [inlined]
 Verified
 
-_Stack.lit
+_Stack.lit [inlined]
 Verified
 
-_Stack.top
+_Stack.top [inlined]
 Verified
+

--- a/tests/resources/golden/inline_stack_minimal_sat.gold
+++ b/tests/resources/golden/inline_stack_minimal_sat.gold
@@ -1,14 +1,15 @@
 main_
 False
 
-_Stack.empty
+_Stack.empty [inlined]
 Verified
 
-_Stack.add
+_Stack.add [inlined]
 Verified
 
-_Stack.lit
+_Stack.lit [inlined]
 Verified
 
-_Stack.top
+_Stack.top [inlined]
 Verified
+

--- a/tests/resources/golden/inline_svar.gold
+++ b/tests/resources/golden/inline_svar.gold
@@ -4,5 +4,6 @@ Verified
 increase_balance
 Verified
 
-add_two
+add_two [inlined]
 Verified
+

--- a/tests/resources/golden/inline_svar_read_write.gold
+++ b/tests/resources/golden/inline_svar_read_write.gold
@@ -4,8 +4,9 @@ False
 thisunsat
 Verified
 
-read_svar
+read_svar [inlined]
 Verified
 
-write_svar
+write_svar [inlined]
 False
+

--- a/tests/resources/golden/inline_svar_read_write_many.gold
+++ b/tests/resources/golden/inline_svar_read_write_many.gold
@@ -4,8 +4,9 @@ False
 thisunsat
 Verified
 
-read_svar
+read_svar [inlined]
 Verified
 
-write_svar
+write_svar [inlined]
 False
+

--- a/tests/resources/golden/inline_svar_sat.gold
+++ b/tests/resources/golden/inline_svar_sat.gold
@@ -4,5 +4,6 @@ Verified
 increase_balance
 False
 
-add_two
+add_two [inlined]
 Verified
+

--- a/tests/resources/golden/pedersen_simple_fake.gold
+++ b/tests/resources/golden/pedersen_simple_fake.gold
@@ -1,5 +1,6 @@
-apply_pedersen
+apply_pedersen [inlined]
 Verified
 
-main
+main [inlined]
 False
+

--- a/tests/resources/golden/range_check_discard.gold
+++ b/tests/resources/golden/range_check_discard.gold
@@ -1,5 +1,6 @@
-range_check_5_times
+range_check_5_times [inlined]
 Verified
 
-discarding_range_check
+discarding_range_check [inlined]
 False
+

--- a/tests/resources/golden/stack_minimal.gold
+++ b/tests/resources/golden/stack_minimal.gold
@@ -10,5 +10,6 @@ Verified
 main_
 Verified
 
-_Stack.empty
+_Stack.empty [inlined]
 Verified
+

--- a/tests/resources/golden/violated_call_pre.gold
+++ b/tests/resources/golden/violated_call_pre.gold
@@ -1,5 +1,6 @@
 transfer
 Verified
 
-main
+main [inlined]
 False
+


### PR DESCRIPTION
Every function that has been inlined by Horus is now marked `[inlined]`.
We can use this normatively in docs to explain:
  - semantics wrt. the implicit True -> True
  - semantics wrt. storage variable interactions
  - semantics wrt. builtin pointers still being checked (as they are an implicit precondition which you don't ever annotate)
  - performance implications (inlining bad, abstraction good)
