### PR TITLE
Add `:::default` oracle suffixes when we don't collapse results

### DIFF
--- a/tests/resources/golden/invalidate_sat.gold
+++ b/tests/resources/golden/invalidate_sat.gold
@@ -1,7 +1,7 @@
 id
 Verified
 
-test1
+test1:::default
 Verified
 
 test1.lab:::T

--- a/tests/resources/golden/sat_cause_42.gold
+++ b/tests/resources/golden/sat_cause_42.gold
@@ -1,7 +1,7 @@
 f
 Verified
 
-main
+main:::default
 Verified
 
 main.loop:::T


### PR DESCRIPTION
This commit addresses some confusing behavior in the output for functions with multiple modules where at least one module is `False`.

Let’s take `func_gauss.cairo` as example, the `gauss()` function has a loop labeled `loop` with it’s corresponding invariant. As everything is correct we get

```console
gauss
Verified

main
Verified
```

But if we break the code inside the loop as to invalidate the invariant, we get something like this:

```console
gauss
Verified

gauss.loop:::T
Verified

gauss.loop:::F
False

main
Verified
```

The verifier is successfully identifying there’s a problem inside the loop, but we still get `gauss Verified`. The reason is because in the first case `gauss Verified` means the whole function is correct (because everything about `gauss()` is packed in one line as everything is `Verified`), but in the second case, `gauss Verified` just means "the module before the loop label has been checked".

To remedy this issue, we now print `gauss:::default` in the second case.

## Examples

Here is the diff of the output changes from this PR on `sat_cause_42.cairo`:

```diff
--- sat_cause_42.gold   2023-01-19 10:50:55.352278049 -0500
+++ sat_cause_42.temp   2023-01-19 12:41:39.052291219 -0500
@@ -1,7 +1,7 @@
 f
 Verified

-main
+main:::default
 Verified

 main.loop:::T
```

For `two_sats.cairo`, the output is unchanged:
https://github.com/NethermindEth/horus-checker/blob/1f20bb8fb90d9aff1281346abff8aa44beee45e6/tests/resources/golden/two_sats.cairo#L1-L15

```console
main
False

test
False
```