### PR TITLE
fix unprocessed labels at rets

### DIFF
--- a/src/Horus/Global.hs
+++ b/src/Horus/Global.hs
@@ -307,6 +307,7 @@ solveContract = do
   lInstructions <- getLabelledInstructions
   inlinables <- getInlinables
   cfg <- runCFGBuildL $ buildCFG lInstructions inlinables
+  verbosePrint cfg
 
   -- For every inlinable function `f`, build the CFG for all functions excluding `f`.
   let fs = toAscList inlinables

--- a/src/Horus/Module.hs
+++ b/src/Horus/Module.hs
@@ -256,7 +256,7 @@ gatherFromSource cfg function fSpec =
       | otherwise = emitPlain pre (Expr.and assertions)
 
     visitLinear SBRich
-      | onFinalNode = emitRich
+      | onFinalNode = emitRich (fs_pre fSpec) (Expr.and $ cfg_assertions cfg ^. ix l)
       | null assertions = visitArcs oracle' acc builder l
       | otherwise = extractPlainBuilder fSpec >>= visitLinear
     visitLinear (SBPlain pre)
@@ -272,8 +272,9 @@ gatherFromSource cfg function fSpec =
     oracle' = updateOracle arcCond callstack' oracle
     assertions = cfg_assertions cfg ^. ix l
     onFinalNode = null (cfg_arcs cfg ^. ix l)
-    emitPlain pre post = emitModule (Module (MSPlain (PlainSpec pre post)) acc oracle' (calledFOfCallEntry $ top callstack') (callstack', l))
-    emitRich = emitModule (Module (MSRich fSpec) acc oracle' (calledFOfCallEntry $ top callstack') (callstack', l))
+    emitPlain pre post = emit . MSPlain $ PlainSpec pre post
+    emitRich pre post = emit . MSRich $ FuncSpec pre post $ fs_storage fSpec
+    emit spec = emitModule $ Module spec acc oracle' (calledFOfCallEntry $ top callstack') (callstack', l)
 
     -- Visit all arcs from the current node.
     --


### PR DESCRIPTION
Hotfix for a bug that would cause labels' annotation not being considered in case said labels were on the same PC as a function's ret.