### PR TITLE
implement collapsing of outermost namespaces

### DIFF
--- a/src/Horus/Global.hs
+++ b/src/Horus/Global.hs
@@ -167,7 +167,7 @@ data SolvingInfo = SolvingInfo
   , si_result :: SolverResult
   , si_inlinable :: Bool
   }
-  deriving (Eq)
+  deriving (Eq, Show)
 
 {- | Construct a function name from a qualified function name and a summary of
  the label(s) (usually just one).


### PR DESCRIPTION
This commit collapses outermost namespaces in the cases where a label includes a scope identifier identical to the function it is in.

The way we do this is by computing the longest common prefix of each name/list of scopes, removing this prefix from all scoped names, and then prepending the prefix itself to the list.

* When there is only one scoped name (the most common case), the prefix
  is the whole thing, and so after filtering out empty lists, we leave
  the input invariant.
* When there are multiple, our concatenation procedure ensures that the
  prefix only appears once.

This is done in the new function `sansCommonAncestor`.