### PR TITLE
fix improper handling of if in stack-ful contexts

### DIFF
--- a/src/Horus/Module/Runner.hs
+++ b/src/Horus/Module/Runner.hs
@@ -9,6 +9,7 @@ import Data.DList (DList)
 import Data.DList qualified as D (singleton)
 import Data.Foldable (toList)
 import Data.Function ((&))
+import Data.Map (Map)
 import Data.Set (Set)
 import Data.Set qualified as Set (empty, insert, member)
 import Data.Text (Text)
@@ -18,7 +19,10 @@ import Horus.Label (Label (..))
 import Horus.Module (Error, Module (..), ModuleF (..), ModuleL (..))
 import Horus.Util (tShow)
 
-type Impl = ReaderT (Set (NonEmpty Label, Label)) (WriterT (DList Module) (Except Error))
+type Impl =
+  ReaderT
+    (Set (NonEmpty Label, Map (NonEmpty Label, Label) Bool, Label))
+    (WriterT (DList Module) (Except Error))
 
 interpret :: ModuleL a -> Impl a
 interpret = iterM exec . runModuleL


### PR DESCRIPTION
```
from starkware.cairo.common.math import assert_not_zero

// @post [ap - 1] == 3
func main() {
    [ap] = 1, ap++;
    assert_not_zero([ap - 1]);
    [ap] = [ap - 1] + 1, ap++;
    [ap] = [ap - 1] + 1, ap++;
    ret;
}
```
This program no longer reports a loop, nor do similar if-y programs of this nature, as far as I can tell anyway :).