### PR TITLE
Change version checking procedure

### DIFF
--- a/horus-check.cabal
+++ b/horus-check.cabal
@@ -137,4 +137,5 @@ executable horus-check
       optparse-applicative,
       pretty-simple,
       text,
-      
+    other-modules:
+      Paths_horus_check


### PR DESCRIPTION
`horus-check` now verifies that a version lies in a certain interval. For the moment it's ```[0.0.6.8, 0.0.7)```.
For the future I suggest that if there's no breaking changes in the compiler output then only the minor number changes.
Otherwise we do ```0.0.n.x -> 0.0.n+1```.  This way we'll be able to maintain the interval as ```[0.0.n, 0.0.n+1)```. 