### PR TITLE
Update `stdout` for tutorial (`[inlined]` marker is gone for `main()`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -656,6 +656,9 @@ horus-check --solver z3 compiled.json spec.json
 
 <sub>Expected output:</sub>
 ```
+Warning: Horus is currently in the *alpha* stage. Please be aware of the
+Warning: known issues: https://github.com/NethermindEth/horus-checker/issues
+
 _Stack.add
 Verified
 
@@ -665,10 +668,10 @@ Verified
 _Stack.top
 Verified
 
-_Stack.empty [inlined]
+main
 Verified
 
-main [inlined]
+_Stack.empty [inlined]
 Verified
 
 ```


### PR DESCRIPTION
This PR addresses a typo found by @Ferinko in the example output for the tutorial in `README.md`:

> I've just noticed a mistake in the expected output of the main example in readme :smile: :smile: :smile: :smile:. I've only seen it 2130489 times so it's understandable to have missed it...
> 
> ```console
> _Stack.add
> Verified
> 
> _Stack.lit
> Verified
> 
> _Stack.top
> Verified
> 
> _Stack.empty [inlined]
> Verified
> 
> main [inlined]
> Verified
> 
> ```
> Main is not supposed to say `[inlined]` and I'm pretty sure it doesn't, this happened with the old version of 'broken' asserts (when the function also said assert) :smile:.

See diff for more info.