### PR TITLE
Detect contradictory premises

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -28,7 +28,7 @@ import Text.ParserCombinators.ReadP (readP_to_S)
 import Horus.Arguments (Arguments (..), argParser, fileArgument, specFileArgument)
 import Horus.ContractDefinition (ContractDefinition, cdSpecs, cd_version)
 import Horus.ContractInfo (mkContractInfo)
-import Horus.Global (SolverResult (..), SolvingInfo (..), cfg_version, solveContract)
+import Horus.Global (HorusResult (..), SolvingInfo (..), cfg_version, solveContract)
 import Horus.Global.Runner qualified as Global (Env (..), run)
 import Horus.SW.Std (stdSpecs)
 import Horus.Util (tShow)
@@ -79,7 +79,7 @@ main' Arguments{..} filename specFileName = do
   infos <- liftIO (Global.run env solveContract) >>= liftEither
   for_ infos $ \si -> liftIO $ do
     TextIO.putStrLn (ppSolvingInfo si)
-  let unknowns = [res | res@(Unknown{}) <- map si_result infos]
+  let unknowns = [res | res@(Timeout{}) <- map si_result infos]
   unless (null unknowns) $ liftIO (TextIO.putStrLn hint')
  where
   hint' = "\ESC[33m" <> (T.strip . T.unlines . map ("hint: " <>) . T.lines) hint <> "\ESC[0m"

--- a/src/Horus/Global.hs
+++ b/src/Horus/Global.hs
@@ -33,7 +33,6 @@ import Horus.CairoSemantics.Runner
   , MemoryVariable (..)
   , debugFriendlyModel
   , makeModel
-  , makePreconditionModel
   )
 import Horus.CallStack (CallStack, initialWithFunc)
 import Horus.Expr qualified as Expr
@@ -214,7 +213,7 @@ solveModule m = do
 outputSmtQueries :: Text -> ConstraintsState -> GlobalL ()
 outputSmtQueries moduleName constraints = do
   fPrime <- p_prime <$> getProgram
-  let query = makeModel constraints fPrime
+  let query = makeModel False constraints fPrime
   Config{..} <- getConfig
   whenJust cfg_outputQueries (writeSmtFile query)
   whenJust cfg_outputOptimizedQueries (writeSmtFileOptimized query)
@@ -267,8 +266,8 @@ solveSMT :: ConstraintsState -> GlobalL HorusResult
 solveSMT cs = do
   Config{..} <- getConfig
   fPrime <- p_prime <$> getProgram
-  let query = makeModel cs fPrime
-  let preQuery = makePreconditionModel cs fPrime
+  let query = makeModel False cs fPrime
+  let preQuery = makeModel True cs fPrime
   res <- runPreprocessorL (PreprocessorEnv memVars cfg_solver cfg_solverSettings) (solve fPrime query)
   preRes <- runPreprocessorL (PreprocessorEnv memVars cfg_solver cfg_solverSettings) (solve fPrime preQuery)
   -- Convert the `SolverResult` to a `HorusResult`.

--- a/tests/resources/golden/contra.cairo
+++ b/tests/resources/golden/contra.cairo
@@ -1,0 +1,5 @@
+// @pre 9 == 10
+// @post $Return.a == 1
+func f(x: felt) -> (a: felt) {
+    return (a=x);
+}

--- a/tests/resources/golden/contra.gold
+++ b/tests/resources/golden/contra.gold
@@ -1,0 +1,2 @@
+f
+Contradictory premises

--- a/tests/resources/golden/contra_lvars.cairo
+++ b/tests/resources/golden/contra_lvars.cairo
@@ -1,0 +1,10 @@
+// @declare $x : felt
+// @declare $y : felt
+// @declare $z : felt
+// @pre $x == 1
+// @pre $y == 2
+// @pre $x == $y
+// @post $Return.a == 1
+func f(x: felt) -> (a: felt) {
+    return (a=x);
+}

--- a/tests/resources/golden/contra_lvars.gold
+++ b/tests/resources/golden/contra_lvars.gold
@@ -1,0 +1,2 @@
+f
+Contradictory premises


### PR DESCRIPTION
This commit implements the logic to run a secondary query that checks whether the preconditions of each function imply `False`. This effectively detects contradictions in the `@pre`.

> #### Example
> 
> Consider the following Cairo program:
> ```cairo
> // @pre 9 == 10
> // @post $Return.a == 1
> func f(x: felt) -> (a: felt) {
>     let y = 4;
>     return (a=x + 2);
> }
> ```
> Horus now prints the following output:
> ```console
> (horus37) user@computer:~/pkgs/horus-checker$ horus-check a.json
> f
> Contradictory preconditions
> ```

We do this by adding an `AssertPre'` constructor to `CairoSemanticsF a`, which we use to gather the preconditions asserts in isolation.

* Add `horus-compile/` to `.gitignore` to allow nesting repos nicely.
* Add `HorusResult` type for representing the types of results the user sees, as distinct from the types of results we can get from the solvers.
* Add docstrings and comments for aforementioned logic.