### PR TITLE
Don't mark functions in `stdSpecsList` as user-annotated

### DIFF
--- a/src/Horus/SW/Std.hs
+++ b/src/Horus/SW/Std.hs
@@ -118,6 +118,33 @@ stdSpecsList =
         }
     )
   ,
+    -- [fp - 2 - k] is always the k-th-to-last argument of the function.
+    -- 
+    -- So [fp - 3] is the last argument, [fp - 4] is the second-to-last, etc.
+    --
+    -- In this case, the function signature is:
+    --
+    -- ```cairo
+    -- func memcpy(dst: felt*, src: felt*, len) {
+    -- ```
+    --
+    -- So we have the following mapping:
+    --  dst == [fp - 5]
+    --  src == [fp - 4]
+    --  len == [fp - 3]
+    ( "starkware.cairo.common.memcpy.memcpy"
+    , let
+        dstPtr = memory (fp - 5)
+        srcPtr = memory (fp - 4)
+        len = memory (fp - 3)
+        dst = memory dstPtr
+        src = memory srcPtr
+        dsts = [memory (dstPtr + fromIntegral i) | i <- [0 .. len - 1]]
+      in emptyFuncSpec
+      { fs_post = memory (memory (fp - 5)) .== memory (memory (fp - 4))
+      }
+    )
+  ,
     ( "starkware.cairo.lang.compiler.lib.registers.get_ap"
     , emptyFuncSpec{fs_post = memory (ap - 1) .== fp - 2}
     )


### PR DESCRIPTION
This commit is the beginnings of a fix for a bug that rears its head when a StarkNet function decorated as `@external` returns a `felt*` pointer. A minimum working example is given below:

```console
(horus37) user@computer:~/pkgs/horus-checker/demos$ ./display.sh array.cairo
~~~~~~~~~~~~~~~{SOURCE}~~~~~~~~~~~~~~
%lang starknet

@external
func f() -> (array_len : felt, array : felt*) {
    alloc_locals;
    // An array of felts.
    local felt_array: felt*;
    assert felt_array[0] = 0;
    assert felt_array[1] = 1;
    assert felt_array[2] = 2;
    return (array_len=3, array=felt_array);
}

~~~~~~~~~~~~~~{RESULT}~~~~~~~~~~~~~~~
Warning: Horus is currently in the *alpha* stage. Please be aware of the
Warning: known issues: https://github.com/NethermindEth/horus-checker/issues

f: ScopedFunction {sf_scopedName = __main__.f, sf_pc = Label 15}
not inlinable: False
isStandardSource: False
f: ScopedFunction {sf_scopedName = __wrappers__.f, sf_pc = Label 49}
not inlinable: True
not wrapper: False
isStandardSource: False
f: ScopedFunction {sf_scopedName = __wrappers__.f_encode_return, sf_pc = Label 30}
not inlinable: True
not wrapper: False
isStandardSource: False
f: ScopedFunction {sf_scopedName = starkware.cairo.common.memcpy.memcpy, sf_pc = Label 0}
not inlinable: True
not wrapper: True
isStandardSource: True
gathering: starkware.cairo.common.memcpy.memcpy
horus-check: user error (There is a loop at PC 5 with no invariant)
```

Note that `isStandardSource` is `True` for `memcpy`.