### PR TITLE
add check for repeated storage_updates up to syntactic equality of ar…

### DIFF
--- a/src/Horus/CFGBuild.hs
+++ b/src/Horus/CFGBuild.hs
@@ -20,7 +20,7 @@ module Horus.CFGBuild
 where
 
 import Control.Arrow (Arrow (second))
-import Control.Monad (unless, when)
+import Control.Monad (when)
 import Control.Monad.Except (MonadError (..))
 import Control.Monad.Free.Church (F, liftF)
 import Data.Coerce (coerce)
@@ -160,8 +160,9 @@ getSalientVertex :: Label -> CFGBuildL Vertex
 getSalientVertex l = do
   verts <- filter (not . isOptimising) <$> getVerts l
   -- This can be at most one, so len <> 1 implies there are no vertices
-  unless (length verts == 1) . throw $ "No vertex with label: " <> tShow l
-  pure $ head verts
+  case verts of
+    [vert] -> pure vert
+    _ -> throw $ "No vertex with label: " <> tShow l
 
 throw :: Text -> CFGBuildL a
 throw t = liftF' (Throw t)

--- a/src/Horus/CFGBuild/Runner.hs
+++ b/src/Horus/CFGBuild/Runner.hs
@@ -56,9 +56,9 @@ verticesLabelledBy cfg l = [v | v <- cfg_vertices cfg, v_label v == l]
 interpret :: CFGBuildL a -> Impl a
 interpret = iterM exec . runCFGBuildL
  where
-  exec (AddVertex l isOptimizing cont) = do
+  exec (AddVertex l optimises cont) = do
     freshVal <- cfgVertexCounter <%= succ
-    let newVertex = Vertex (Text.pack (show freshVal)) l isOptimizing
+    let newVertex = Vertex (Text.pack (show freshVal)) l optimises
     vs <- gets cfg_vertices
     -- Currently, the design is such that it is convenient to be able to distinguish
     -- 'the unique vertex the entire codebase relies on' from vertices that exist

--- a/src/Horus/CairoSemantics.hs
+++ b/src/Horus/CairoSemantics.hs
@@ -26,7 +26,7 @@ import Data.Traversable (for)
 import Lens.Micro ((^.), _1)
 
 import Horus.CallStack as CS (CallEntry, CallStack)
-import Horus.Expr (Cast (..), Expr (ExistsFelt, (:+)), Ty (..), (.&&), (./=), (.<), (.<=), (.==), (.=>), (.||))
+import Horus.Expr (Cast (..), Expr ((:+)), Ty (..), (.&&), (./=), (.<), (.<=), (.==), (.=>), (.||))
 import Horus.Expr qualified as Expr
 import Horus.Expr qualified as TSMT
 import Horus.Expr.Util (gatherLogicalVariables, suffixLogicalVariables)
@@ -227,12 +227,8 @@ preparePost ap fp expr isOptim = do
     then do
       memVars <- getMemVars
       post <- storageRemoval expr
-      ($ memVars) <$> exMemoryRemoval (substitute "fp" fp (substitute "ap" ap (sansExists post)))
-    else prepare' ap fp $ sansExists expr
- where
-  sansExists e = case e of
-    ExistsFelt _ innerExpr -> innerExpr
-    _ -> e
+      ($ memVars) <$> exMemoryRemoval (substitute "fp" fp (substitute "ap" ap post))
+    else prepare' ap fp expr
 
 encodeApTracking :: Text -> ApTracking -> Expr TFelt
 encodeApTracking traceDescr ApTracking{..} =

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -5,38 +5,38 @@
 
 packages:
 - completed:
-    commit: dd03ca119ddcd50bde52fbe40c96eb60cc1d6338
-    git: https://github.com/yav/simple-smt.git
     name: simple-smt
-    pantry-tree:
-      sha256: 52b7da75230a4cbc27007b8560371a007d3ce5f4773023dc8f1f43299e99a414
-      size: 357
     version: 0.9.7
-  original:
-    commit: dd03ca119ddcd50bde52fbe40c96eb60cc1d6338
     git: https://github.com/yav/simple-smt.git
-- completed:
-    commit: dd7f75f253c42053e1ebb75aa2c498ef64465177
-    git: https://github.com/IagoAbal/haskell-z3.git
-    name: z3
     pantry-tree:
-      sha256: 540b083755abfe88c5338162505b04db576c0a7072e676c1d27001f2f4cc67f9
-      size: 2204
-    version: '408.2'
+      size: 357
+      sha256: 52b7da75230a4cbc27007b8560371a007d3ce5f4773023dc8f1f43299e99a414
+    commit: dd03ca119ddcd50bde52fbe40c96eb60cc1d6338
   original:
-    commit: dd7f75f253c42053e1ebb75aa2c498ef64465177
+    git: https://github.com/yav/simple-smt.git
+    commit: dd03ca119ddcd50bde52fbe40c96eb60cc1d6338
+- completed:
+    name: z3
+    version: '408.2'
     git: https://github.com/IagoAbal/haskell-z3.git
+    pantry-tree:
+      size: 2204
+      sha256: 540b083755abfe88c5338162505b04db576c0a7072e676c1d27001f2f4cc67f9
+    commit: dd7f75f253c42053e1ebb75aa2c498ef64465177
+  original:
+    git: https://github.com/IagoAbal/haskell-z3.git
+    commit: dd7f75f253c42053e1ebb75aa2c498ef64465177
 - completed:
     hackage: co-log-core-0.3.1.0@sha256:9794bdedd1391decd0e22bdfe2b11abcb42e6cff7a4531e1f8882890828f4e63,3816
     pantry-tree:
-      sha256: d4cc089c40c5052ee02f91eafa567e0a239908aabc561dfa6080ba3bfc8c25bd
       size: 584
+      sha256: d4cc089c40c5052ee02f91eafa567e0a239908aabc561dfa6080ba3bfc8c25bd
   original:
     hackage: co-log-core-0.3.1.0@sha256:9794bdedd1391decd0e22bdfe2b11abcb42e6cff7a4531e1f8882890828f4e63,3816
 snapshots:
 - completed:
-    sha256: 57d4ce67cc097fea2058446927987bc1f7408890e3a6df0da74e5e318f051c20
     size: 618884
     url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/19/7.yaml
+    sha256: 57d4ce67cc097fea2058446927987bc1f7408890e3a6df0da74e5e318f051c20
   original:
     url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/19/7.yaml

--- a/tests/resources/golden/svar_syntactic_reassign.cairo
+++ b/tests/resources/golden/svar_syntactic_reassign.cairo
@@ -1,0 +1,29 @@
+%lang starknet
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+
+@storage_var
+func balance() -> (res: felt) {
+}
+
+@storage_var
+func schmalance(i: felt) -> (res: felt) {
+}
+
+// @storage_update balance() := balance() + amount
+// @storage_update balance() := balance() + amount + 42
+// @storage_update schmalance(41) := schmalance(3) + amount + 42
+// @storage_update schmalance(42) := schmalance(5) + amount
+func increase_balance{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    amount: felt
+) {
+    let (res) = balance.read();
+    balance.write(res + amount);
+    return ();
+}
+
+// @post $Return.res == balance()
+func get_balance{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (res: felt) {
+    let (res) = balance.read();
+    return (res=res);
+}

--- a/tests/resources/golden/svar_syntactic_reassign.gold
+++ b/tests/resources/golden/svar_syntactic_reassign.gold
@@ -1,0 +1,6 @@
+get_balance
+Verified
+
+increase_balance
+Unknown
+Error: Re-declared storage update annotations for: __main__.balance


### PR DESCRIPTION
…guments

We can very easily check for syntactic equality of storage_vars being accessed in storage_update and thus improve UX substantially with very little work in case a user accidentally tries to update the same storage twice. This does not generalize to cases of semantic equality e.g. an attempt to specify update for `svar(1 + 2)` will be considered distinct from an update to `svar(2 + 1)`.