### PR TITLE
Remove distinction between rich and plain specs

### DIFF
--- a/src/Horus/Global.hs
+++ b/src/Horus/Global.hs
@@ -39,7 +39,7 @@ import Horus.Expr qualified as Expr
 import Horus.Expr.Util (gatherLogicalVariables)
 import Horus.FunctionAnalysis (ScopedFunction (ScopedFunction, sf_pc), isWrapper)
 import Horus.Logger qualified as L (LogL, logDebug, logError, logInfo, logWarning)
-import Horus.Module (Module (..), ModuleData (md_calledF, md_prog), ModuleL, gatherModules, getModuleNameParts, getPreCheckedFuncWithCallStack, moduleData)
+import Horus.Module (Module (..), ModuleL, gatherModules, getModuleNameParts)
 import Horus.Preprocessor (HorusResult (..), PreprocessorL, SolverResult (..), goalListToTextList, optimizeQuery, solve)
 import Horus.Preprocessor.Runner (PreprocessorEnv (..))
 import Horus.Preprocessor.Solvers (Solver, SolverSettings, filterMathsat, includesMathsat, isEmptySolver)
@@ -160,7 +160,7 @@ makeModules (cfg, allow) =
 
 extractConstraints :: Module -> GlobalL ConstraintsState
 extractConstraints mdl =
-  runCairoSemanticsL (initialWithFunc . md_calledF . moduleData $ mdl) (encodeModule mdl)
+  runCairoSemanticsL (initialWithFunc . m_calledF $ mdl) (encodeModule mdl)
 
 data SolvingInfo = SolvingInfo
   { si_moduleName :: Text
@@ -197,7 +197,7 @@ solveModule m = do
   identifiers <- getIdentifiers
   let (qualifiedFuncName, labelsSummary, oracleSuffix, preCheckingSuffix) = getModuleNameParts identifiers m
       moduleName = mkLabeledFuncName qualifiedFuncName labelsSummary <> oracleSuffix <> preCheckingSuffix
-      inlinable = md_calledF (moduleData m) `elem` Set.map sf_pc inlinables
+      inlinable = m_calledF m `elem` Set.map sf_pc inlinables
   result <- removeMathSAT m (mkResult moduleName)
   pure
     SolvingInfo
@@ -205,7 +205,7 @@ solveModule m = do
       , si_funcName = qualifiedFuncName
       , si_result = result
       , si_inlinable = inlinable
-      , si_preCheckingContext = getPreCheckedFuncWithCallStack m
+      , si_preCheckingContext = m_preCheckedFuncAndCallStack m
       }
  where
   mkResult :: Text -> GlobalL HorusResult
@@ -254,7 +254,7 @@ removeMathSAT :: Module -> GlobalL a -> GlobalL a
 removeMathSAT m run = do
   conf <- getConfig
   let solver = cfg_solver conf
-  usesLvars <- or <$> traverse instUsesLvars (md_prog (moduleData m))
+  usesLvars <- or <$> traverse instUsesLvars (m_prog m)
   if includesMathsat solver && usesLvars
     then do
       let solver' = filterMathsat solver


### PR DESCRIPTION
This PR uses `FuncSpec` for everything. A `PlainSpec` is now just a `FuncSpec` with an empty `Storage` map. As a result, we no longer have a distinction between rich specs and plain specs. Now everything is handled by `encodeModule`, which is just `encodeRichSpec` with the logic of `encodePlainSpec` inlined.

We remove all of the following:
* `ModuleData` (this was a bad idea in current state, sorry!)
* `ModuleSpec`
* `PlainSpec`
* `RichSpec`