### PR TITLE
Add mathsat installation to Github actions workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,8 +68,13 @@ jobs:
 
       - name: Install SMT solvers
         run: |
+          echo "${{ secrets.MATHSAT_INSTALL_DEPLOY_KEY }}" >> mathsat_id_ed25519
+          chmod 400 mathsat_id_ed25519
+          ssh-agent bash -c 'ssh-add mathsat_id_ed25519; git clone git@github.com:NethermindEth/mathsat-install.git'
+          cp mathsat-install/install-mathsat.sh ./scripts/ci/install-mathsat.sh
           sh ./scripts/ci/install-z3-linux-amd64.sh
           sh ./scripts/ci/install-cvc5-linux.sh
+          sh ./scripts/ci/install-mathsat.sh
 
       - uses: actions/setup-python@v4
         with:

--- a/tests/resources/bats-template
+++ b/tests/resources/bats-template
@@ -26,7 +26,7 @@ test_case() {
     temp_file="${base}.temp"
 
     horus-compile "$test_file" --output "$compiled_file" --spec_output "$spec_file"
-    stack run horus-check "$compiled_file" "$spec_file" -- -s cvc5 -s z3 -t 100000 &> "$temp_file" || true
+    stack run horus-check "$compiled_file" "$spec_file" -- -s cvc5 -s mathsat -s z3 -t 100000 &> "$temp_file" || true
     compare "${gold_file}" "${temp_file}"
     rm "$compiled_file"
     rm "$spec_file"


### PR DESCRIPTION
We clone from a private repo in the `NethermindEth` organization. Brings CI test running time from ~17m to ~10m.